### PR TITLE
fix(scraper): drop unsupported sampling params for GPT-5 models

### DIFF
--- a/src/scrapecsharp/scrapsummary/scraper/Program.cs
+++ b/src/scrapecsharp/scrapsummary/scraper/Program.cs
@@ -435,11 +435,7 @@ URL: {blogUrl}
 """;
 
 		var payload = new ChatCompletionRequest(
-			800,
-			0.9,
-			0.95,
-			0,
-			0,
+			4000,
 			_deployment,
 			[new ChatMessage("user", prompt)]);
 
@@ -464,11 +460,12 @@ URL: {blogUrl}
 			}
 
 			var completion = JsonSerializer.Deserialize<ChatCompletionResponse>(responseBody, JsonOptions.Default);
-			var message = completion?.Choices?.FirstOrDefault()?.Message?.Content;
+			var choice = completion?.Choices?.FirstOrDefault();
+			var message = choice?.Message?.Content;
 			if (string.IsNullOrWhiteSpace(message))
 			{
 				Console.Error.WriteLine(
-					$"OpenAI response did not contain a summary message. Endpoint={_endpoint}, Deployment={_deployment}");
+					$"OpenAI response did not contain a summary message. Endpoint={_endpoint}, Deployment={_deployment}, FinishReason={choice?.FinishReason ?? "(none)"}");
 				Console.Error.WriteLine($"OpenAI raw response: {TruncateForLog(responseBody, 4000)}");
 				return AppDefaults.SummaryFailedMessage;
 			}
@@ -551,11 +548,7 @@ internal sealed record GitHubRepository(string Owner, string Name)
 internal sealed record BlogContentResult(string Title, string Content, string Error);
 
 internal sealed record ChatCompletionRequest(
-	[property: JsonPropertyName("max_completion_tokens")] int MaxTokens,
-	double Temperature,
-	double TopP,
-	int FrequencyPenalty,
-	int PresencePenalty,
+	[property: JsonPropertyName("max_completion_tokens")] int MaxCompletionTokens,
 	string Model,
 	ChatMessage[] Messages);
 
@@ -563,7 +556,9 @@ internal sealed record ChatMessage(string Role, string Content);
 
 internal sealed record ChatCompletionResponse(ChatChoice[]? Choices);
 
-internal sealed record ChatChoice(ChatMessage? Message);
+internal sealed record ChatChoice(
+	ChatMessage? Message,
+	[property: JsonPropertyName("finish_reason")] string? FinishReason);
 
 internal static class JsonOptions
 {


### PR DESCRIPTION
## なぜ

GitHub Actions 上で要約処理が以下のエラーで失敗していました。

```
Unsupported value: 'temperature' does not support 0.9 with this model.
Only the default (1) value is supported.
```

GPT-5 系 (reasoning models) は `temperature` / `top_p` / `frequency_penalty` / `presence_penalty` のいずれもデフォルト値以外を受け付けません。従来 Azure OpenAI 向けに設定していたサンプリングパラメータが、GPT-5 デプロイに切り替えたタイミングで全て非互換になったのが原因です。

## 変更内容

- `ChatCompletionRequest` から `Temperature` / `TopP` / `FrequencyPenalty` / `PresencePenalty` を削除し、ペイロードからも 0.9 / 0.95 / 0 / 0 を除去。送信するのは `model` / `messages` / `max_completion_tokens` のみにしました。
- `max_completion_tokens` を 800 から 4000 に引き上げ。GPT-5 は reasoning tokens がこの予算を消費するため、800 のままだと本文が返らず `finish_reason=length` で空応答になるリスクがありました。
- `ChatChoice` に `finish_reason` を追加し、本文が空だった場合のエラーログに出力するようにしました。今後の原因特定を容易にするためのログ拡充です。

## 動作確認

- `dotnet build src/scrapecsharp/scrapsummary/scraper` でエラー 0 / 警告 0 を確認。

## 備考

`max_tokens` → `max_completion_tokens` の置換は前回の PR で対応済みのため、本 PR ではサンプリング系パラメータの GPT-5 互換化のみを扱っています。

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>